### PR TITLE
Ensure that the code designator in the BatchControl matches the BatchHeader

### DIFF
--- a/examples/ach/batch_example.rb
+++ b/examples/ach/batch_example.rb
@@ -86,6 +86,28 @@ describe ACH::Batch do
       debits.header.service_class_code.should == 225
     end
 
+    it 'should set BatchControl#company_identification_code_designator from BatchHeader' do
+      batch = new_batch
+      batch.header.company_identification_code_designator = "3"
+      batch.control.company_identification_code_designator.should be_nil # default values are only set when calling to_ach
+      batch.to_ach
+      batch.control.company_identification_code_designator.should == "3"
+    end
+
+    it 'should set BatchControl#company_identification from BatchHeader' do
+      batch = new_batch
+      batch.control.company_identification.should be_nil
+      batch.to_ach
+      batch.control.company_identification.should == "123456789"
+    end
+
+    it 'should set BatchControl#originating_dfi_identification from BatchHeader' do
+      batch = new_batch
+      batch.control.originating_dfi_identification.should be_nil
+      batch.to_ach
+      batch.control.originating_dfi_identification.should == "00000000"
+    end
+
     it 'should not override BatchHeader#service_class_code if already set' do
       # Granted that I can't imagine this every being used...
       batch = new_batch

--- a/lib/ach/batch.rb
+++ b/lib/ach/batch.rb
@@ -47,6 +47,11 @@ module ACH
         @control.service_class_code = @header.service_class_code 
       end
       
+      if ! @header.company_identification_code_designator.nil?
+        @control.company_identification_code_designator =
+          @header.company_identification_code_designator
+      end
+
       @control.company_identification = @header.company_identification
       @control.originating_dfi_identification = @header.originating_dfi_identification
       @control.batch_number = @header.batch_number

--- a/lib/ach/records/batch_header.rb
+++ b/lib/ach/records/batch_header.rb
@@ -12,7 +12,7 @@ module ACH::Records
     field :company_discretionary_data, String,
         lambda { |f| left_justify(f, 20)}, ''
     field :company_identification_code_designator, String, lambda {|f| f}, '1',
-        /\A(1|3){1}\z/
+        /\A[13]\z/
     field :company_identification, String,
         lambda {|f| f}, nil, /\A\d{9}\z/,
         'Company Tax ID'


### PR DESCRIPTION
I noticed that the I had to explicitly set the company_identification_code_designator in both the BatchHeader and the BatchControl or the control would default to 1. I added logic to ensure that the BatchControl matches the BatchHeader.
