### PR TITLE
Fix output & validation for immediate dest/origin

### DIFF
--- a/examples/ach/records/file_header_example.rb
+++ b/examples/ach/records/file_header_example.rb
@@ -1,0 +1,39 @@
+require 'example_helper'
+
+describe ACH::Records::FileHeader do
+  before(:each) do
+    @header = ACH::Records::FileHeader.new
+    @header.immediate_destination_name = 'destination'
+    @header.immediate_destination = '123456789'
+    @header.immediate_origin_name = 'origin'
+    @header.immediate_origin = '123456789'
+  end
+
+  describe '#to_ach' do
+    it 'has 94 characters' do
+      @header.to_ach.should have(94).characters
+    end
+  end
+
+  describe '#immediate_origin_to_ach' do
+    it 'adds a leading space when only 9 digits' do
+      @header.immediate_origin_to_ach.should == ' 123456789'
+    end
+
+    it 'does not add a leading space when 10 digits' do
+      @header.immediate_origin = '1234567890'
+      @header.immediate_origin_to_ach.should == '1234567890'
+    end
+  end
+
+  describe '#immediate_origin_to_ach' do
+    it 'adds a leading space when only 9 digits' do
+      @header.immediate_destination_to_ach.should == ' 123456789'
+    end
+
+    it 'does not add a leading space when 10 digits' do
+      @header.immediate_destination = '1234567890'
+      @header.immediate_destination_to_ach.should == '1234567890'
+    end
+  end
+end

--- a/lib/ach/records/file_header.rb
+++ b/lib/ach/records/file_header.rb
@@ -1,11 +1,11 @@
 module ACH::Records
   class FileHeader < Record
     @fields = []
-    
+
     const_field :record_type, '1'
     const_field :priority_code, '01'
-    field :immediate_destination, String, nil, /\A\s?\d{9}\z/
-    field :immediate_origin, String, nil, /\A\d{9,10}\z/
+    field :immediate_destination, String, lambda { |f| f.rjust(10) }, nil, /\A\d{9,10}\z/
+    field :immediate_origin, String, lambda { |f| f.rjust(10) }, nil, /\A\d{9,10}\z/
     field :transmission_datetime, Time,
         lambda { |f| f.strftime('%y%m%d%H%M')},
         lambda { Time.now }


### PR DESCRIPTION
- The validator was being sent as the wrong parameter before, and the
  field was not being padded properly, causing the header to allow
  fields of the wrong length.
