### PR TITLE
strip non ascii characters in fields since banks won't handle them

### DIFF
--- a/examples/ach/batch_example.rb
+++ b/examples/ach/batch_example.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'example_helper'
 
 describe ACH::Batch do
@@ -118,6 +119,11 @@ describe ACH::Batch do
     it 'should truncate fields that exceed the length in left_justify' do
       @credit.individual_name = "Employee Name That Is Much Too Long"
       @credit.individual_name_to_ach.should == "Employee Name That Is "
+    end
+
+    it 'should strip non ascii characters' do
+      @credit.individual_name = "Jacob Møller"
+      @credit.individual_name_to_ach.should == "Jacob Mller          "
     end
   end
 end

--- a/lib/ach.rb
+++ b/lib/ach.rb
@@ -36,6 +36,6 @@ end
 
 # Include Records module to simplify accessing Records classes.
 module ACH
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
   include Records
 end

--- a/lib/ach/field_identifiers.rb
+++ b/lib/ach/field_identifiers.rb
@@ -1,5 +1,14 @@
 module ACH
   module FieldIdentifiers
+
+    # these are used to convert non ascii characters to UTF-8
+
+    ENCODING_OPTIONS = {
+      :invalid           => :replace,  # Replace invalid byte sequences
+      :undef             => :replace,  # Replace anything not defined in ASCII
+      :replace           => '',        # Use a blank for those replacements
+    }
+
     # NOTE: the msg parameter is unused and should be removed when the API can change
     def field(name, klass, stringify = nil, default = nil, validate = nil, msg ='')
       fields << name
@@ -38,11 +47,11 @@ module ACH
           end
         end
 
-        if stringify.nil?
-          return val
-        else
-          stringify.call(val)
+        if !stringify.nil?
+          val = stringify.call(val)
         end
+
+        val.encode Encoding.find('ASCII'), ENCODING_OPTIONS
       end
     end
 

--- a/lib/ach/version.rb
+++ b/lib/ach/version.rb
@@ -1,3 +1,3 @@
 module ACH
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end


### PR DESCRIPTION
For example a customer name with special chars would make it through to the nacha file and the bank can't handle it.

I've only tested this in 1.9.
