### PR TITLE
Fix company_identification default validator to allow alphanumeric data

### DIFF
--- a/lib/ach/records/batch_header.rb
+++ b/lib/ach/records/batch_header.rb
@@ -14,7 +14,7 @@ module ACH::Records
     field :company_identification_code_designator, String, nil, '1',
         /\A[0-9 ]\z/
     field :company_identification, String,
-        nil, nil, /\A\d{9}\z/
+        nil, nil, /\A[a-zA-Z0-9 ]{9}\z/
     # TODO This should be used to determine whether other records are valid for
     # this code. Should there be a Class for each code?
     # The default of PPD is purely for my benefit (Jared Morgan)


### PR DESCRIPTION
ACH Rules allow for this field to be alphanumeric, so I modified the default validator accordingly.
