### PR TITLE
Add a Length Validation to the Entry Record's Trace Number

### DIFF
--- a/lib/ach/records/entry_detail.rb
+++ b/lib/ach/records/entry_detail.rb
@@ -20,7 +20,8 @@ module ACH::Records
         lambda { |f| sprintf('%01d', f)}, 0
     field :originating_dfi_identification, String,
         nil, nil, /\A\d{8}\z/
-    field :trace_number, Integer, lambda { |f| sprintf('%07d', f)}
+    field :trace_number, Integer, lambda { |f| sprintf('%07d', f)}, nil,
+        lambda { |n| n.to_s.length <= 7 }
 
     def credit?
       CREDIT_RECORD_TRANSACTION_CODE_ENDING_DIGITS.include?(@transaction_code[1..1])


### PR DESCRIPTION
This check ensures that the integer fed to the Entry Record's trace number is no longer than 7 digits. The documentation calls for the Trace Number to be 15 digits, with the first 8 holding the Originating DFI Identification.
