### PR TITLE
Handle encoding issues with fixed-length records

### DIFF
--- a/lib/ach/ach_file.rb
+++ b/lib/ach/ach_file.rb
@@ -14,7 +14,7 @@ module ACH
       @control = Records::FileControl.new
 
       if data
-        if (data =~ /\n|\r\n/).nil?
+        if (data.encode(Encoding.find('ASCII'),ENCODING_OPTIONS) =~ /\n|\r\n/).nil?
           parse_fixed(data)
         else
           parse(data)
@@ -71,7 +71,9 @@ module ACH
     end
 
     def parse_fixed data
-      parse data.scan(/.{94}/).join("\n")
+      # replace with a space to preserve the record-lengths
+      encoded_data = data.encode(Encoding.find('ASCII'),{:invalid => :replace, :undef => :replace, :replace => ' '})
+      parse encoded_data.scan(/.{94}/).join("\n")
     end
 
     def parse data


### PR DESCRIPTION
Ran into situations where non-ascii files from Fed were causing fixed-length record parsing to fail. Patched this issue in this commit.
