### PR TITLE
Don't overwrite trace numbers for the last parsed batch

### DIFF
--- a/lib/ach/ach_file.rb
+++ b/lib/ach/ach_file.rb
@@ -76,7 +76,6 @@ module ACH
     end
 
     def parse data
-      trace_number = 0
       fh =  self.header
       batch = nil
       bh = nil
@@ -140,7 +139,6 @@ module ACH
       end
 
       self.batches << batch unless batch.nil?
-      batch.entries.each{ |entry| entry.trace_number = (trace_number += 1) }
       to_s
     end
   end


### PR DESCRIPTION
I don't really understand the original intent behind the code that I deleted. It doesn't seem like you should just overwrite the trace numbers for the last batch.

Not sure if it was just a copy paste error or what.

Please correct me if I've missed something.