### PR TITLE
Add class to calculate next federal reserve effective date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+cache: bundler
+language: ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ach (0.4.9)
+      holidays (>= 1.2.0, < 3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +11,7 @@ GEM
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     diff-lcs (1.2.5)
+    holidays (2.0.0)
     rake (10.1.1)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #ACH
 
+![](https://travis-ci.org/jm81/ach.svg)
+
 ach is a Ruby helper for builder ACH files. In particular, it helps with field
 order and alignment, and adds padding lines to end of file.
 

--- a/ach.gemspec
+++ b/ach.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.2')
+
+  s.add_runtime_dependency('holidays', '>= 1.2.0', '< 3.0.0')
 end

--- a/lib/ach.rb
+++ b/lib/ach.rb
@@ -27,6 +27,7 @@ require 'iconv' if RUBY_VERSION < '1.9'
 require 'ach/field_identifiers'
 require 'ach/ach_file'
 require 'ach/batch'
+require 'ach/next_federal_reserve_effective_date'
 require 'ach/version'
 
 # Require records files

--- a/lib/ach/next_federal_reserve_effective_date.rb
+++ b/lib/ach/next_federal_reserve_effective_date.rb
@@ -1,0 +1,40 @@
+require 'holidays'
+
+module ACH
+  class NextFederalReserveEffectiveDate
+    def initialize(submission_date)
+      @submission_date = submission_date
+    end
+
+    def result
+      @result = @submission_date
+      advance_to_next_business_day
+      advance_extra_day_if_submission_date_is_holiday_or_weekend
+      @result
+    end
+
+    private
+
+    def advance_extra_day_if_submission_date_is_holiday_or_weekend
+      if holiday_or_weekend?(@submission_date)
+        advance_to_next_business_day
+      end
+    end
+
+    def advance_to_next_business_day
+      @result = @result.next_day
+
+      while holiday_or_weekend?(@result)
+        @result = @result.next_day
+      end
+    end
+
+    def holiday?(date)
+      Holidays.on(date, :federal_reserve).any?
+    end
+
+    def holiday_or_weekend?(date)
+      date.saturday? || date.sunday? || holiday?(date)
+    end
+  end
+end

--- a/spec/ach/next_federal_reserve_effective_date_spec.rb
+++ b/spec/ach/next_federal_reserve_effective_date_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe ACH::NextFederalReserveEffectiveDate do
+  context '#result' do
+    subject { ACH::NextFederalReserveEffectiveDate.new(run_date).result }
+
+    context 'when today and tomorrow are regular weekdays' do
+      let(:run_date) { Date.new(2012, 12, 20) }
+
+      it 'returns tomorrow' do
+        expect(subject).to eq(Date.new(2012, 12, 21))
+      end
+    end
+
+    context 'when today is Friday and Monday is not a holiday' do
+      let(:run_date) { Date.new(2012, 11, 2) }
+
+      it 'returns the Monday after' do
+        expect(subject).to eq(Date.new(2012, 11, 5))
+      end
+    end
+
+    context 'when today is Friday and Monday is a holiday' do
+      let(:run_date) { Date.new(2012, 05, 25) }
+
+      it 'returns the Tuesday after' do
+        expect(subject).to eq(Date.new(2012, 5, 29))
+      end
+    end
+
+    context 'when today is Monday and a holiday' do
+      let(:run_date) { Date.new(2012, 5, 28) }
+
+      it 'returns the Wednesday after' do
+        expect(subject).to eq(Date.new(2012, 5, 30))
+      end
+    end
+
+    context 'when today is Monday and not a holiday and tomorrow is a holiday' do
+      let(:run_date) { Date.new(2012, 12, 24) }
+
+      it 'returns the Wednesday after' do
+        expect(subject).to eq(Date.new(2012, 12, 26))
+      end
+    end
+
+    context 'when today is Saturday and Monday is not a holiday' do
+      let(:run_date) { Date.new(2012, 11, 3) }
+
+      it 'returns the Tuesday after' do
+        expect(subject).to eq(Date.new(2012, 11, 6))
+      end
+    end
+
+    context 'when today is Saturday and Monday is a Holiday' do
+      let(:run_date) { Date.new(2012, 5, 26) }
+
+      it 'returns the Wednesday after' do
+        expect(subject).to eq(Date.new(2012, 5, 30))
+      end
+    end
+
+    context 'when today is Thursday and a holiday' do
+      let(:run_date) { Date.new(2012, 11, 22) }
+
+      it 'returns the Monday after' do
+        expect(subject).to eq(Date.new(2012, 11, 26))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Would this be useful to include in the ach gem? It adds a runtime dependency, but it's probably easy enough to make that optional. I'd also probably want to add some info about this to the README.

Background: The bank that handles our ACH files requires that the effective date of an ACH batch be the next business day for the Fed, or if today is not a business day, then the business day after that. They say this is common, but I don't really know how common it is. I was surprised there wasn't anything out there to do this, so I found myself rolling my own.

I also added Travis CI support, so you'd just have to flip it on at www.travis-ci.org.