### PR TITLE
Add support for records to be case sensitive

### DIFF
--- a/lib/ach/records/record.rb
+++ b/lib/ach/records/record.rb
@@ -11,8 +11,11 @@ module ACH
       
       extend(FieldIdentifiers)
       
+      attr_accessor :case_sensitive
+      
       def to_ach
-        self.class.fields.collect { |f| send("#{f}_to_ach") }.join('').upcase
+        to_ach = self.class.fields.collect { |f| send("#{f}_to_ach") }.join('')
+        case_sensitive ? to_ach : to_ach.upcase
       end
     end
   end


### PR DESCRIPTION
This actually turned out to be simpler than I thought. Basically, when creating anything that's an instance of record, you can selectively turn on case sensitivity for that record by setting `case_sensitive` to a truthy value.

I didn't want to make this an option for the entire file because, in all honestly, I don't think this is going to see regular use. In the NACHA files I'm generating, I've seen exactly **one** value where sensitivity mattered (`ACH::Records::BatchHeader#company_name`).

So this code ends up allowing case sensitivity in a `BatchHeader`:

```ruby
batch = ACH::Batch.new
bh = batch.header
bh.case_sensitive = true
```

I didn't see a test for `ACH::Records::Record` so I wasn't sure where to add one. I do know this works as advertised though. Heh. If you want me to add a test, let me know with a bit of guidance on where you'd like it to go.