### PR TITLE
Support leading characters for `immediate_origin`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---profile --colour --format progress --tag focus
+--profile --colour --format progress --tag focus --order rand

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+bundler_args: "--jobs 4 --retry 3"
 cache: bundler
 language: ruby
-rvm: 2.0.0
+sudo: false
+rvm:
+- 2.0.0
+- 2.1.10
+- 2.2.5
+- 2.3.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,25 +7,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.9.5)
+    ZenTest (4.11.0)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     diff-lcs (1.2.5)
     holidays (4.0.0)
-    rake (10.1.1)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.1)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    rake (11.1.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.1)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.2)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
 
 PLATFORMS
   ruby

--- a/lib/ach/records/file_header.rb
+++ b/lib/ach/records/file_header.rb
@@ -5,7 +5,7 @@ module ACH::Records
     const_field :record_type, '1'
     const_field :priority_code, '01'
     field :immediate_destination, String, lambda { |f| f.rjust(10) }, nil, /\A\d{9,10}\z/
-    field :immediate_origin, String, lambda { |f| f.rjust(10) }, nil, /\A\d{9,10}\z/
+    field :immediate_origin, String, lambda { |f| f.rjust(10) }, nil, /\A[A-Z\d\s]{1}?\d{9}\z/
     field :transmission_datetime, Time,
         lambda { |f| f.strftime('%y%m%d%H%M')},
         lambda { Time.now }

--- a/spec/ach/records/file_header_spec.rb
+++ b/spec/ach/records/file_header_spec.rb
@@ -24,9 +24,24 @@ describe ACH::Records::FileHeader do
       @header.immediate_origin = '1234567890'
       expect(@header.immediate_origin_to_ach).to eq('1234567890')
     end
+
+    it 'allows a leading letter' do
+      @header.immediate_origin = 'A123456789'
+      expect(@header.immediate_origin_to_ach).to eq('A123456789')
+    end
+
+    it 'allows a leading number' do
+      @header.immediate_origin = '1234567890'
+      expect(@header.immediate_origin_to_ach).to eq('1234567890')
+    end
+
+    it 'allows a leading space' do
+      @header.immediate_origin = ' 123456789'
+      expect(@header.immediate_origin_to_ach).to eq(' 123456789')
+    end
   end
 
-  describe '#immediate_origin_to_ach' do
+  describe '#immediate_destination_to_ach' do
     it 'adds a leading space when only 9 digits' do
       expect(@header.immediate_destination_to_ach).to eq(' 123456789')
     end


### PR DESCRIPTION
According to several versions of the ACH specification, the value for immediate origin may contain an optional leading uppercase letter, number, or space. Several banks require variations on this format. We have been successfully using this in production for some time now with good results. 