### PR TITLE
Allow file_header immediate_destination to be blank in support of Canadian ACH files

### DIFF
--- a/lib/ach/records/file_header.rb
+++ b/lib/ach/records/file_header.rb
@@ -4,7 +4,7 @@ module ACH::Records
 
     const_field :record_type, '1'
     const_field :priority_code, '01'
-    field :immediate_destination, String, lambda { |f| f.rjust(10) }, nil, /\A\d{9,10}\z/
+    field :immediate_destination, String, lambda { |f| f.rjust(10) }, nil, /\A(\d{9,10}|)\z/
     field :immediate_origin, String, lambda { |f| f.rjust(10) }, nil, /\A[A-Z\d\s]{1}?\d{9}\z/
     field :transmission_datetime, Time,
         lambda { |f| f.strftime('%y%m%d%H%M')},


### PR DESCRIPTION
This tiny change allows the immediate_destination field to be optionally set to blank.  The ACH file specification for Canada requires it to be blank. 

See:
  * [ACH Debit File Layout](https://www.rbcroyalbank.com/ach/file-451769.pdf)
  * [ACH Credit File Layout](https://www.rbcroyalbank.com/ach/file-451768.pdf)