### PR TITLE
New Feature: Allow for same-day ACH in headers

### DIFF
--- a/lib/ach.rb
+++ b/lib/ach.rb
@@ -32,6 +32,7 @@ require 'ach/ach_file'
 require 'ach/batch'
 require 'ach/next_federal_reserve_effective_date'
 require 'ach/version'
+require 'ach/string_formatting_helper'
 
 # Require records files
 require 'ach/records/record'

--- a/lib/ach/records/batch_header.rb
+++ b/lib/ach/records/batch_header.rb
@@ -22,8 +22,9 @@ module ACH::Records
         lambda { |f| f.upcase }, 'PPD', /\A\w{3}\z/
     field :company_entry_description, String,
         lambda { |f| left_justify(f, 10)}
+    # This field allows for marking the batch as same-day for the bank by passing in ex: SD1300
     field :company_descriptive_date, Time,
-        lambda { |f| f.strftime('%y%m%d')},
+        ACH::StringFormattingHelper.method(:stringify_with_same_day).to_proc,
         lambda { Time.now }
     field :effective_entry_date, Time,
         lambda { |f| f.strftime('%y%m%d')}

--- a/lib/ach/string_formatting_helper.rb
+++ b/lib/ach/string_formatting_helper.rb
@@ -1,0 +1,9 @@
+module ACH
+  module StringFormattingHelper
+    # Passing in SD to the date signifies same-day to banks. This is used for the company_descriptive_date
+    def self.stringify_with_same_day(f)
+      return f.upcase if f.to_s.upcase.match(/^SD\d+$/)
+      f.strftime('%y%m%d')
+    end
+  end
+end

--- a/spec/ach/records/batch_header_spec.rb
+++ b/spec/ach/records/batch_header_spec.rb
@@ -7,6 +7,13 @@ describe ACH::Records::BatchHeader do
 
   it_behaves_like 'a batch summary'
 
+  describe 'same day ach' do
+    it 'should create with string company_descriptive_date' do
+      @record.company_descriptive_date = 'sd1300'
+      expect(@record.company_descriptive_date_to_ach).to eq('SD1300')
+    end
+  end
+
   describe '#standard_entry_class_code' do
     it 'should default to PPD' do
       expect(@record.standard_entry_class_code_to_ach).to eq('PPD')


### PR DESCRIPTION
Our banking partner requires to change the :company_descriptive_date in the batch header to be "SD1300" (Same day 1pm). This change will allow us to enter SD1300 as the company_descriptive_date and not throw NoMethodError: undefined method `strftime' for "SD1300":String