### PR TITLE
Add an error subclass for unrecognized type code

### DIFF
--- a/lib/ach.rb
+++ b/lib/ach.rb
@@ -20,13 +20,11 @@ module ACH
     225, # ACH Debits Only
     280  # ACH Automated Accounting Advices
   ]
-
-  class InvalidError < RuntimeError
-  end
 end
 
 require 'time'
 require 'iconv' if RUBY_VERSION < '1.9'
+require 'ach/errors'
 require 'ach/field_identifiers'
 require 'ach/ach_file'
 require 'ach/batch'

--- a/lib/ach/ach_file.rb
+++ b/lib/ach/ach_file.rb
@@ -143,7 +143,7 @@ module ACH
         when '9'
           # skip
         else
-          raise "Didn't recognize type code #{type} for this line:\n#{line}"
+          raise UnrecognizedTypeCode, "Didn't recognize type code #{type} for this line:\n#{line}"
         end
       end
 

--- a/lib/ach/errors.rb
+++ b/lib/ach/errors.rb
@@ -1,0 +1,4 @@
+module ACH
+  class Error < RuntimeError; end
+  class InvalidError < Error; end
+end

--- a/lib/ach/errors.rb
+++ b/lib/ach/errors.rb
@@ -1,4 +1,5 @@
 module ACH
   class Error < RuntimeError; end
   class InvalidError < Error; end
+  class UnrecognizedTypeCode < Error; end
 end

--- a/spec/ach/parse_spec.rb
+++ b/spec/ach/parse_spec.rb
@@ -73,5 +73,9 @@ describe "Parse" do
       expect(ad.addenda_information).to eq('INVALID')
     end
 
+    it 'should raise an appropriate error if the type code was not recognized' do
+      ach_file = ACH::ACHFile.new
+      expect { ach_file.parse('INVALID DATA') }.to raise_error(ACH::UnrecognizedTypeCode)
+    end
   end
 end


### PR DESCRIPTION
It seems like in certain cases `ACHFile` would happily swallow data that doesn't look like ACH, but will predictably crash when trying to parse it. This PR adds an error class that will be raise when that happen allowing gem users to reliably rescue from this exception.

Also move all errors into a separate file and subclassed from `ACH::Error` for consistency.