### PR TITLE
Remove linefeed and carriage return characters from individual name field

### DIFF
--- a/lib/ach/records/entry_detail.rb
+++ b/lib/ach/records/entry_detail.rb
@@ -16,7 +16,7 @@ module ACH::Records
     field :account_number, String, lambda { |f| left_justify(f, 17)}
     field :amount, Integer, lambda { |f| sprintf('%010d', f)}
     field :individual_id_number, String, lambda { |f| left_justify(f, 15)}
-    field :individual_name, String, lambda { |f| left_justify(f, 22)}
+    field :individual_name, String, lambda { |f| left_justify(f.gsub(/[\n\r]/, ''), 22)}
     field :discretionary_data, String, lambda { |f| left_justify(f, 2)}, '  '
     field :addenda_record_indicator, Integer,
         lambda { |f| sprintf('%01d', f)}, 0

--- a/spec/ach/batch_spec.rb
+++ b/spec/ach/batch_spec.rb
@@ -113,6 +113,11 @@ describe ACH::Batch do
       expect(@credit.individual_name_to_ach).to eq("Employee Name That Is ")
     end
 
+    it 'should remove new line characters' do
+      @credit.individual_name = "Multiline\nName\r\n"
+      expect(@credit.individual_name_to_ach).to eq("MultilineName         ")
+    end
+
     it 'should strip non ascii characters' do
       @credit.individual_name = "Jacob Møller"
       expect(@credit.individual_name_to_ach).to eq("Jacob Mller           ")


### PR DESCRIPTION
So it turns out if there is a new line character in this field, the entire NACHA file gets corrupted.
This removes any newline characters so that can't happen.

This one got us pretty bad in production, so hoping to get it merged ASAP for everyone else.
Thanks so much!