### PR TITLE
Add README comment about File Creation Date timezones in file header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-#ACH
+# ACH
 
 [![Build Status](https://travis-ci.org/jm81/ach.svg?branch=master)](https://travis-ci.org/jm81/ach)
 
 ach is a Ruby helper for builder ACH files. In particular, it helps with field
 order and alignment, and adds padding lines to end of file.
 
-**This library has only been used in one production application and for very
+**This library has only been used in two production applications and for very
 limited purposes. Please test thoroughly before using in a production
 environment.**
 
 See [ACH::Builder](http://search.cpan.org/~tkeefer/ACH-Builder-0.03/lib/ACH/Builder.pm)
 for a similar Perl library
 
-##Example
+## Example
 
 You should consult a copy of the [ACH Rules](http://www.nacha.org) for details
 on individual fields. You can probably obtain a copy from your bank.
@@ -30,6 +30,11 @@ fh.immediate_destination = '000000000'
 fh.immediate_destination_name = 'BANK NAME'
 fh.immediate_origin = '000000000'
 fh.immediate_origin_name = 'BANK NAME'
+# Optional - This value is used in the File Creation Date/Time attributes - if excluded will default to Time.now
+# Note that you may wish to modify the time zone here if your environment has a different time zone than the banks
+# For example if your server is in UTC and the bank's is in US/Eastern, any files sent after 8pm Eastern/Midnight UTC
+#   would have a File Creation Date of the next day from the bank's perspective
+fh.transmission_datetime = Time.now
 
 # Batch
 batch = ACH::Batch.new
@@ -73,6 +78,6 @@ ach.batches.first.entries.first.addenda.first.payment_data
 
 **Note:** When adding an amount to your ach file, it needs to be in cents. So you'll want to multiply any dollar amounts by 100
 
-##Copyright
+## Copyright
 
 Copyright (c) 2008-2009 Jared E Morgan, released under the MIT license


### PR DESCRIPTION
We had a bank we work with get persnickety about the File Creation Date being a Saturday for files sent to them on Friday nights 

This seemed like it was worth a README warning but not a breaking change to the default value, but let me know if you can think of any code changes to accomodate this for everyone! 

We ended up using `Time.zone.now` in our rails codebase that uses this gem